### PR TITLE
Add schema descriptions as jsdoc

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -187,7 +187,9 @@ var convertElement = function( schemaName, name, element, required, options )
         }
     }
 
-    return [ output, type ];
+    var descr = element.description ? "/** " + element.description + " */ " : "";
+
+    return [ descr + output, type ];
 };
 
 var convertSchema = function( schema, options, debug )
@@ -222,6 +224,11 @@ var convertSchema = function( schema, options, debug )
         //
         var output  = [];
         var types   = [];
+
+        if ( schema.description )
+        {
+            output.push( "/** " + schema.description + " */" );
+        }
 
         if ( extend.length )
         {


### PR DESCRIPTION
When schema elements have a description property, this should be added as jsdoc to the generated typescript. This commit adds the most basic support for this.